### PR TITLE
chore: use semantic-release from devDependencies in Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,4 +33,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx semantic-release
+        run: npx --no-install semantic-release


### PR DESCRIPTION
## Description
Version of `semantic-release` is controlled via `devDependencies` so we should make sure that this version is used in GA workflow for release.

## Motivation and Context
`semantic-release` at [v20.0.0](https://github.com/semantic-release/semantic-release/releases/tag/v20.0.0) became ESM-only package which requires Node.js `>=v18`.
